### PR TITLE
Clean up special quote characters in hrefs

### DIFF
--- a/module.web/src/components/dnn-security-center/dnn-security-center.tsx
+++ b/module.web/src/components/dnn-security-center/dnn-security-center.tsx
@@ -62,7 +62,7 @@ export class DnnSecurityCenter {
   }
 
   private decodeHtml(text: string): string {
-    return text.replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>');
+    return text.replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace('”', '').replace('”', '');
   }
 
   render() {


### PR DESCRIPTION
For the few URLs, there were some special quote characters that were making the path relative.  This PR strips those characters to make the URL usable and absolute.