### PR TITLE
Update backend and some frontend dependencies

### DIFF
--- a/Module.csproj
+++ b/Module.csproj
@@ -92,19 +92,19 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DotNetNuke.Core">
-      <Version>9.10.2</Version>
+      <Version>9.11.1</Version>
     </PackageReference>
     <PackageReference Include="DotNetNuke.Instrumentation">
-      <Version>9.10.2</Version>
+      <Version>9.11.1</Version>
     </PackageReference>
     <PackageReference Include="DotNetNuke.Web">
-      <Version>9.10.2</Version>
+      <Version>9.11.1</Version>
     </PackageReference>
     <PackageReference Include="DotNetNuke.WebApi">
-      <Version>9.10.2</Version>
+      <Version>9.11.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNet.WebApi.Core">
-      <Version>5.2.7</Version>
+      <Version>5.2.9</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers">
       <Version>6.0.0</Version>
@@ -115,7 +115,7 @@
       <Version>10.0.3</Version>
     </PackageReference>
     <PackageReference Include="NSwag.Annotations">
-      <Version>13.17.0</Version>
+      <Version>13.19.0</Version>
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers">
       <Version>1.1.118</Version>
@@ -125,7 +125,9 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="resources\App_LocalResources\ModelValidation.resx" />
-    <EmbeddedResource Include="resources\App_LocalResources\UI.resx" />
+    <EmbeddedResource Include="resources\App_LocalResources\UI.resx">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -77,19 +77,19 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="DotNetNuke.Abstractions">
-      <Version>9.10.2</Version>
+      <Version>9.11.1</Version>
     </PackageReference>
     <PackageReference Include="DotNetNuke.Core">
-      <Version>9.10.2</Version>
+      <Version>9.11.1</Version>
     </PackageReference>
     <PackageReference Include="DotNetNuke.Instrumentation">
-      <Version>9.10.2</Version>
+      <Version>9.11.1</Version>
     </PackageReference>
     <PackageReference Include="DotNetNuke.Web">
-      <Version>9.10.2</Version>
+      <Version>9.11.1</Version>
     </PackageReference>
     <PackageReference Include="DotNetNuke.WebApi">
-      <Version>9.10.2</Version>
+      <Version>9.11.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel">
       <Version>17.3.2</Version>

--- a/manifest.dnn
+++ b/manifest.dnn
@@ -15,7 +15,7 @@
       <releaseNotes src="ReleaseNotes.html" />
       <azureCompatible>True</azureCompatible>
       <dependencies>
-        <dependency type="coreVersion">09.10.02</dependency>
+        <dependency type="coreVersion">09.11.01</dependency>
       </dependencies>
       <components>
         <component type="Assembly">
@@ -27,7 +27,7 @@
             <assembly>
               <name>NSwag.Annotations.dll</name>
               <path>bin</path>
-              <version>13.17.0</version>
+              <version>13.19.0</version>
             </assembly>
           </assemblies>
         </component>

--- a/module.web/package-lock.json
+++ b/module.web/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.0",
       "license": "MIT",
       "devDependencies": {
-        "@dnncommunity/dnn-elements": "^0.15.1",
+        "@dnncommunity/dnn-elements": "^0.18.0",
         "@stencil/core": "^2.18.0",
         "@stencil/eslint-plugin": "^0.4.0",
         "@stencil/sass": "^2.0.0",
@@ -19,7 +19,7 @@
         "eslint": "^7.32.0",
         "eslint-plugin-react": "^7.31.8",
         "eslint-plugin-tsdoc": "^0.2.17",
-        "typescript": "^4.8.4"
+        "typescript": "^4.9.5"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -126,9 +126,9 @@
       }
     },
     "node_modules/@dnncommunity/dnn-elements": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@dnncommunity/dnn-elements/-/dnn-elements-0.15.1.tgz",
-      "integrity": "sha512-OnN7DQu6FkKXYVDAWkyb2UmJnxxwWYVus0912XnJtRSe6cEt12NbnHmN/Ay3PVGA5gPnEND33hv3KVrOT8cDqg==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@dnncommunity/dnn-elements/-/dnn-elements-0.18.0.tgz",
+      "integrity": "sha512-ohi8G5sf07P2khHa4g/KHk5Rv3+tFnsyknbuyohNW9ermID4EvAj50q9ojN85H39iijBhfEz2Vh5/4JtGNbfJg==",
       "dev": true
     },
     "node_modules/@eslint/eslintrc": {
@@ -2532,9 +2532,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -2713,9 +2713,9 @@
       }
     },
     "@dnncommunity/dnn-elements": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@dnncommunity/dnn-elements/-/dnn-elements-0.15.1.tgz",
-      "integrity": "sha512-OnN7DQu6FkKXYVDAWkyb2UmJnxxwWYVus0912XnJtRSe6cEt12NbnHmN/Ay3PVGA5gPnEND33hv3KVrOT8cDqg==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@dnncommunity/dnn-elements/-/dnn-elements-0.18.0.tgz",
+      "integrity": "sha512-ohi8G5sf07P2khHa4g/KHk5Rv3+tFnsyknbuyohNW9ermID4EvAj50q9ojN85H39iijBhfEz2Vh5/4JtGNbfJg==",
       "dev": true
     },
     "@eslint/eslintrc": {
@@ -4445,9 +4445,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "unbox-primitive": {

--- a/module.web/package.json
+++ b/module.web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dnn-securitycenter",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
@@ -23,7 +23,7 @@
     "generate": "stencil generate"
   },
   "devDependencies": {
-    "@dnncommunity/dnn-elements": "^0.15.1",
+    "@dnncommunity/dnn-elements": "^0.18.0",
     "@stencil/core": "^2.18.0",
     "@stencil/eslint-plugin": "^0.4.0",
     "@stencil/sass": "^2.0.0",
@@ -33,7 +33,7 @@
     "eslint": "^7.32.0",
     "eslint-plugin-react": "^7.31.8",
     "eslint-plugin-tsdoc": "^0.2.17",
-    "typescript": "^4.8.4"
+    "typescript": "^4.9.5"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
This PR updates backend dependencies from dependabot, but we can only go to DNN 9.11.1 at this time.

This PR also updates some of the frontend devDependencies.  We'll handle the Stencil updates from v2 to v3 via a separate PR.